### PR TITLE
Extension cleanup

### DIFF
--- a/gecko_sdk_extensions/nc_efr32_watchdog_extension/inc/nc_efr32_wdog.h
+++ b/gecko_sdk_extensions/nc_efr32_watchdog_extension/inc/nc_efr32_wdog.h
@@ -19,8 +19,7 @@
 #include "em_cmu.h"
 #include "em_wdog.h"
 #include "em_rmu.h"
-#include "sli_cpc_timer.h"
 #include "sl_component_catalog.h"
 
 void nc_enable_watchdog(void);
-void nc_periodic_timer(sli_cpc_timer_handle_t *handle, void *data);
+void nc_poke_watchdog(void);

--- a/gecko_sdk_extensions/nc_efr32_watchdog_extension/nc_efr32_watchdog.slsdk
+++ b/gecko_sdk_extensions/nc_efr32_watchdog_extension/nc_efr32_watchdog.slsdk
@@ -1,0 +1,7 @@
+﻿# Properties file for Simplicity Studio metadata
+id=uc.extension.nc_erf32_watchdog
+
+version=1.0.0
+
+label=EFR32 Watchdog
+description=EFR32 Watchdog.

--- a/gecko_sdk_extensions/nc_efr32_watchdog_extension/src/nc_efr32_wdog.c
+++ b/gecko_sdk_extensions/nc_efr32_watchdog_extension/src/nc_efr32_wdog.c
@@ -83,7 +83,7 @@ void nc_enable_watchdog(void)
 }
 
 
-void nc_poke_watchdog()
+void nc_poke_watchdog(void)
 {
   CORE_DECLARE_IRQ_STATE;
   CORE_ENTER_ATOMIC();


### PR DESCRIPTION
Back-port of warnings cleanup from Nabu Casa repo and addition of slsdk file needed by Simplicity Studio.